### PR TITLE
BugFix - $category->setTranslation Methode / Readme-Fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ $category = Category::find(1);
 $category->setTranslation('name', 'en', 'Name in English');
 
 // Get category translation
-$category->setTranslation('name', 'en');
+$category->getTranslation('name', 'en');
 
 // Get category name in default locale
 $category->name;

--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ $category = Category::create([
     'name' => [
         'en' => 'New Category Name',
     ],
-
     'children' => [
         [
             'name' => [

--- a/README.md
+++ b/README.md
@@ -362,10 +362,15 @@ $category = Category::create([
 
     'children' => [
         [
-            'name' => 'Bar',
-
+            'name' => [
+                'en' => 'New Category Name Child',
+            ],
             'children' => [
-                [ 'name' => 'Baz' ],
+                [
+                    'name' => [
+                        'en' => 'New Category Name Child Child',
+                    ],
+                ],
             ],
         ],
     ],

--- a/src/Category.php
+++ b/src/Category.php
@@ -155,7 +155,7 @@ class Category extends Model
     {
         return $this->morphedByMany($class, 'categorizable', config('rinvex.category.tables.categorizables'), 'category_id', 'categorizable_id');
     }
-    
+
     /**
      * Enforce clean slugs.
      *

--- a/src/Category.php
+++ b/src/Category.php
@@ -155,31 +155,7 @@ class Category extends Model
     {
         return $this->morphedByMany($class, 'categorizable', config('rinvex.category.tables.categorizables'), 'category_id', 'categorizable_id');
     }
-
-    /**
-     * Set the translatable name attribute.
-     *
-     * @param string $value
-     *
-     * @return void
-     */
-    public function setNameAttribute($value)
-    {
-        $this->attributes['name'] = json_encode(! is_array($value) ? [app()->getLocale() => $value] : $value);
-    }
-
-    /**
-     * Set the translatable description attribute.
-     *
-     * @param string $value
-     *
-     * @return void
-     */
-    public function setDescriptionAttribute($value)
-    {
-        $this->attributes['description'] = ! empty($value) ? json_encode(! is_array($value) ? [app()->getLocale() => $value] : $value) : null;
-    }
-
+    
     /**
      * Enforce clean slugs.
      *


### PR DESCRIPTION
My default language is German (de).
The following code does not work:

```
$category = Category::createByName('Meine neue Kategorie BugFix');
$category->setTranslation('name', 'en', 'My New Category BugFix')->save();
```
I now use the spatie/laravel-translatable  library and removed the accessors in Category-Model. The spatie/laravel-translatable  library already has a workaround.

### Before:
![2017-03-29 19_35_19-admin-panel - c__xampp_htdocs_admin-panel - _app_http_controllers_frontend_](https://cloud.githubusercontent.com/assets/4435288/24468955/2ca337f0-14ba-11e7-8c79-8f7160324c53.png)
![2017-03-29 19_31_54-unnamed_admin_panel_categories_ - heidisql 9 4 0 5143](https://cloud.githubusercontent.com/assets/4435288/24468922/126acaba-14ba-11e7-95bd-139156a9aee6.png)

### Afterwards:
![2017-03-29 19_35_58-admin-panel - c__xampp_htdocs_admin-panel - _app_http_controllers_frontend_](https://cloud.githubusercontent.com/assets/4435288/24469010/55f92da8-14ba-11e7-895d-8a35bfba0f4f.png)
![2017-03-29 19_34_16-unnamed_admin_panel_categories_ - heidisql 9 4 0 5143](https://cloud.githubusercontent.com/assets/4435288/24469001/4d7010ca-14ba-11e7-954e-b815b07b93a7.png)

### Create-Methode - New Handling:
```
$category = Category::create([
            'name' => [
                'en' => 'New Category Name',
            ],

            'children' => [
                [
                    'name' => [
                        'en' => 'New Category Name Child',
                    ],
                    'children' => [
                        [
                            'name' => [
                                'en' => 'New Category Name Child Child',
                            ],
                        ],
                    ],
                ],
            ],
        ]);
```

### README:
A minimal error in the description is removed within the README.